### PR TITLE
fix: uploaded URL path

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -128,7 +128,7 @@ export class EasyS3Client {
             expiresIn: options.expires,
         })
 
-        const objectUrl = `${this.endpoint}/${options.bucket}/${options.folder}${fileName}`
+        const objectUrl = `${this.endpoint}/${options.bucket}/${options.folder}/${fileName}`
 
         await options.successCallbacks.signedURLCreated({
             objectUrl: objectUrl,


### PR DESCRIPTION
Currently, when I upload a file, I get back a URL that looks like this:

```
https://s3.<region>.backblazeb2.com/<bucket>/<folder><id>.png
```

However, accessing this URL does not work and you get an error that the file does not exist. If I manually add a slash `/` between `<folder>` and `<id>`, the URL is correct.

I tried defining the folder with a tailing slash like this: `foldername/`, but this also does not work, then the URL needs to be: `/foldername//<id>.png` with two slashes.

It seems like this slash is missing in the generated URL from the library. This PR should fix it.